### PR TITLE
chore(deploy): add docker-compose.dokploy.yml for pure-git Dokploy deploy

### DIFF
--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -1,0 +1,7 @@
+services:
+  cp-demo-server:
+    build: .
+    environment:
+      - ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
+    restart: unless-stopped


### PR DESCRIPTION
## What

Adds a minimal root `docker-compose.dokploy.yml` so this repo deploys on Dokploy via pure-git: Dokploy clones the repo (sourceType=git, composePath=`./docker-compose.dokploy.yml`), the build context is present, and `build: .` uses the existing Dockerfile.

## Compose

```yaml
services:
  cp-demo-server:
    build: .
    environment:
      - ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
    restart: unless-stopped
```

## Details

- **Build**: `build: .` — the app's existing `Dockerfile` (Flask, `python run.py`).
- **Internal port**: 8080 (`EXPOSE 8080` + `app.run(host='0.0.0.0', port=8080)`). No `ports:` host publishing — Dokploy's `create_domain` handles Traefik routing to the internal 8080.
- **Env**: reads `ADMIN_USERNAME` (default `admin`) and `ADMIN_PASSWORD` from the injected `.env` via `${VAR}` interpolation — same names the app already uses (`app/views.py`). No secrets hardcoded.
- **No bundled proxy, no `container_name`** (Dokploy randomizes).
- **No volume**: `app/data/` seed content (CSVs, seed DBs, malware samples, certs) is baked into the image and re-seeded at boot via `load_csv_to_db()`; mounting a volume there would shadow the baked-in seeds and break the app.

`docker compose -f docker-compose.dokploy.yml config` validates cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)