### PR TITLE
docs: overhaul README for Threat Prevention Server

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,14 +1,29 @@
-# CP Demo Server
+# Threat Prevention Server
+
+A Flask-based Check Point threat-prevention demo/data server for exercising security controls in a lab — trigger IPS signatures, download real (encrypted-at-rest) malware samples, and generate Threat Emulation test files on demand.
 
 ![Python](https://img.shields.io/badge/Python-3.12-blue.svg)
 ![Flask](https://img.shields.io/badge/Flask-3.1.0-lightgrey.svg)
 ![Docker](https://img.shields.io/badge/Docker-ready-2496ED.svg)
-![License](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Auth](https://img.shields.io/badge/Auth-Login%20Protected-green.svg)
-![Encryption](https://img.shields.io/badge/Samples-AES--128%20Encrypted-red.svg)
+![Samples](https://img.shields.io/badge/Samples-AES--128%20Encrypted-red.svg)
 
-A Flask-based threat prevention demo server for testing Check Point security controls locally — IPS triggers, real malware downloads, and threat emulation file generation.
+Part of the [Dev Hub](https://github.com/alshawwaf/dev-hub) ecosystem — deploy the whole suite with [ubuntu-dokploy-ai](https://github.com/alshawwaf/ubuntu-dokploy-ai).
 
+> The repository is named `cp_demo_server`; the app's display name is **Threat Prevention Server**.
+
+---
+
+## Overview
+
+Threat Prevention Server is a self-contained target/generator for validating Check Point threat-prevention blades during a PoV or lab. Point a gateway at it and you can:
+
+- Fire 40+ IPS protection signatures at a chosen target IP to generate logs and prove blocking.
+- Browse and download 225 real malware samples (stored encrypted, decrypted only in memory at download) to test Anti-Virus / URL filtering.
+- Generate Threat Emulation test files across 14 formats with configurable malicious payloads, and optionally email them as attachments.
+- Serve HTTPS-inspection helper material and IoC feeds for endpoint / threat-intel demos.
+
+Every route sits behind a login, and every malware sample is AES-128 encrypted at rest so the host AV never sees plaintext signatures.
 
 ---
 
@@ -16,108 +31,18 @@ A Flask-based threat prevention demo server for testing Check Point security con
 
 | Module | Description |
 |--------|-------------|
-| **IPS Attacks** | Trigger 40+ IPS protection signatures against a target IP |
-| **Malware Samples** | Browse and download 225 real malware samples (encrypted at rest) |
-| **Threat Emulation** | Generate malicious files in 14 formats with configurable payloads |
-| **Email Delivery** | Send generated files as email attachments via SMTP |
-| **JSON API + Swagger** | `POST /api/run_attack` JSON endpoint; every route is documented in the Swagger UI at `/apidocs/` |
+| **IPS Attacks** (`/ips`) | Trigger 40+ IPS protection signatures against a target IP; also exposed as a JSON API (`POST /api/run_attack`) |
+| **Malware Files** (`/av`) | Browse and download 225 real malware samples across 14 categories, decrypted in memory on download |
+| **File Generator / Threat Emulation** (`/te`) | Generate malicious test files in 14 formats with configurable payloads |
+| **Email Delivery** | Send generated files as SMTP attachments using UI-configured mail settings |
+| **HTTPS Inspection & IoC** (`/https_inspection`) | Certificate download plus IoC CSV/PDF/DOCX feeds for inspection and threat-intel demos |
+| **JSON API + Swagger** | Every route is documented in the Swagger UI at `/apidocs/` |
 
 ---
 
-## Security Design
+## Screenshots
 
-### Login Protection
-
-All routes require authentication. Default credentials:
-
-| Username | Password |
-|----------|----------|
-| `admin` | `Cpwins@2026!1` |
-
-Override the defaults with the `ADMIN_USERNAME` and `ADMIN_PASSWORD` environment variables.
-
-### Malware Samples — Encrypted at Rest
-
-All 225 malware samples are stored as **AES-128-CBC encrypted** (`.enc`) files — both on disk and in this repository. The host antivirus never sees plaintext signatures.
-
-- Files are decrypted **in memory only** at download time — plaintext never touches the filesystem
-- Encryption key is stored at `app/data/.secret.key`
-- To encrypt newly added samples: `python scripts/encrypt_samples.py`
-
----
-
-## Quick Start — Docker (Recommended)
-
-```bash
-git clone -b GA https://github.com/alshawwaf/cp_demo_server.git
-cd cp_demo_server
-docker build -t cp_demo_server:latest .
-docker run -d --name cp_demo_server -p 8080:8080 --restart unless-stopped cp_demo_server:latest
-```
-
-Open **http://localhost:8080** and log in with `admin / Cpwins@2026!1`
-
-> Malware samples are pre-encrypted in the repo. No extra steps needed — clone, build, run.
-
----
-
-## Quick Start — Local Python
-
-```bash
-# Install system dependencies (Debian/Ubuntu)
-sudo apt update && sudo apt install -y \
-  python3-virtualenv libpcap-dev libffi-dev \
-  build-essential gcc libcurl4-openssl-dev mingw-w64
-
-# Set up virtual environment
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
-
-# Run
-python run.py
-```
-
-Open **http://127.0.0.1:8080**
-
----
-
-## Project Structure
-
-```
-cp_demo_server/
-├── app/
-│   ├── data/
-│   │   ├── .secret.key              # AES encryption key for malware samples
-│   │   ├── malware_samples/         # 225+ samples stored as .enc files
-│   │   ├── generated_files/         # TE-generated downloadable files
-│   │   ├── ioc_files/               # IoC CSV and PDF test files
-│   │   ├── certificate/             # TLS/SSL certificates
-│   │   └── email_config/            # SMTP configuration (JSON)
-│   ├── templates/
-│   │   ├── login.html               # Login page
-│   │   ├── base.html                # Base layout
-│   │   ├── index.html               # Home
-│   │   ├── ips.html                 # IPS module
-│   │   ├── av.html                  # Malware browser
-│   │   └── te.html                  # Threat emulation
-│   ├── static/                      # CSS, JS, favicon
-│   ├── crypto_util.py               # At-rest encryption/decryption module
-│   ├── views.py                     # All route handlers
-│   ├── file_generator.py            # TE file generation logic
-│   ├── attack_generator.py          # Network attack simulation
-│   ├── db.py                        # SQLite helpers
-│   └── email_service.py             # Flask-Mail wrapper
-├── scripts/
-│   └── encrypt_samples.py           # Encrypt new malware samples in-place
-├── tests/
-│   ├── trigger_attacks.py           # Remote IPS trigger script
-│   ├── test_malware_downloads.py    # Remote malware download tester
-│   └── README.md
-├── Dockerfile
-├── requirements.txt
-└── run.py
-```
+![Threat Prevention Server demo](app/data/readme_assets/cp_demo_server_demo.gif)
 
 ---
 
@@ -125,7 +50,7 @@ cp_demo_server/
 
 ### IPS Attacks (`/ips`)
 
-Trigger Check Point IPS signatures against a configured target IP. Ships with 40+ protections (loaded from `app/data/ips_protections_demo.csv`). Also available via the JSON API:
+Trigger Check Point IPS signatures against a configured target IP. Ships with 40+ protections loaded from `app/data/ips_protections_demo.csv`. The saved target IP is stored in the session so you can fire signatures one after another. Also available as JSON:
 
 ```bash
 curl -X POST http://localhost:8080/api/run_attack \
@@ -136,9 +61,9 @@ curl -X POST http://localhost:8080/api/run_attack \
 
 > `protection_name` must match a name from `app/data/ips_protections_demo.csv` exactly. The endpoint requires an authenticated session (log in first and pass the session cookie).
 
-### Malware Browser (`/av`)
+### Malware Files (`/av`)
 
-Browse and download real malware samples across 14 categories. Files are decrypted in memory on download — your AV only scans the encrypted blobs on disk:
+Browse and download real malware samples across 14 categories. Files are decrypted in memory on download — your AV only ever scans the encrypted `.enc` blobs on disk:
 
 ```
 Banking-Malware  Email-Worm  Joke     Net-Worm  Pony       RAT
@@ -146,7 +71,7 @@ Ransomware       Spyware     Stealer  Trojan    Virus      Worm
 eicar            rogues
 ```
 
-### Threat Emulation (`/te`)
+### File Generator / Threat Emulation (`/te`)
 
 Generate malicious test files in these formats:
 
@@ -154,13 +79,90 @@ Generate malicious test files in these formats:
 pdf  docx  pptx  xlsx  rtf  exe  exe-64bit  elf  dylib  jpg  png  bmp  gif  tiff
 ```
 
-Optional payload embeddings: URLs, scripts, images, video, audio, 3D content, sensitive links, data submission forms.
+Optional payload embeddings: URLs, scripts, images, video, audio, 3D content, embedded PDF, external-app links, sensitive links, and data-submission forms. Generated files can be downloaded, deleted, or emailed as attachments.
 
-> **Note — network attack generator:** `app/attack_generator.py` contains a Scapy-based proof-of-concept for raw network attacks (ICMP/SYN/UDP flood, Ping of Death, ARP poisoning, DNS spoofing, DHCP starvation, HTTP flood, NTP amplification, Slowloris). It is **not exposed** through any route or the navbar — there is no `/attack_generators` endpoint. Treat it as reference code only; the running app surfaces the three modules above (IPS, Malware, Threat Emulation).
+> **Note — network attack generator:** `app/attack_generator.py` contains a Scapy-based proof-of-concept for raw network attacks (ICMP/SYN/UDP flood, Ping of Death, ARP poisoning, DNS spoofing, DHCP starvation, HTTP flood, NTP amplification, Slowloris). It is **not exposed** through any route or the navbar. Treat it as reference code only; the running app surfaces the modules above.
 
 ---
 
-## Remote Testing Scripts
+## Quick start — Docker (recommended)
+
+```bash
+git clone -b GA https://github.com/alshawwaf/cp_demo_server.git
+cd cp_demo_server
+docker build -t cp_demo_server:latest .
+docker run -d --name cp_demo_server -p 8080:8080 --restart unless-stopped cp_demo_server:latest
+```
+
+Open **http://localhost:8080** and log in (see [Configuration](#configuration)).
+
+> Malware samples are pre-encrypted in the repo — no extra steps: clone, build, run.
+
+## Quick start — local Python
+
+```bash
+# System dependencies (Debian/Ubuntu)
+sudo apt update && sudo apt install -y \
+  python3-venv build-essential gcc libcurl4-openssl-dev mingw-w64
+
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python run.py
+```
+
+Open **http://127.0.0.1:8080**. `run.py` initializes the SQLite databases and loads the IPS protection CSV on startup.
+
+---
+
+## Deployment
+
+This app deploys automatically as part of the [Dev Hub](https://github.com/alshawwaf/dev-hub) suite via [ubuntu-dokploy-ai](https://github.com/alshawwaf/ubuntu-dokploy-ai), reachable at **threat.&lt;your-domain&gt;**.
+
+The repo ships a [`docker-compose.dokploy.yml`](docker-compose.dokploy.yml) that builds the image and wires the admin credentials from environment variables:
+
+```yaml
+services:
+  cp-demo-server:
+    build: .
+    environment:
+      - ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
+    restart: unless-stopped
+```
+
+Set `ADMIN_PASSWORD` (and optionally `ADMIN_USERNAME`) in the Dokploy environment for the service. The container listens on port **8080**; Traefik/Dokploy handles TLS termination and routing.
+
+---
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ADMIN_USERNAME` | `admin` | Username for the single admin login |
+| `ADMIN_PASSWORD` | `Cpwins@2026!1` | Password for the admin login — **override in any shared deployment** |
+
+Email delivery is configured at runtime from the UI (**File Generator → email settings**) and persisted to `app/data/email_config/email_config.json` (SMTP server, port, encryption type, sender, default recipient, subject, body) — not via environment variables.
+
+---
+
+## Security design
+
+### Login protection
+
+All routes are wrapped by a `login_required` decorator and require an authenticated session. The server uses a single admin account whose password is stored only as a Werkzeug hash in memory; override the defaults with `ADMIN_USERNAME` / `ADMIN_PASSWORD`.
+
+### Malware samples — encrypted at rest
+
+All 225 malware samples are stored **AES-128 encrypted** (Fernet: AES-128-CBC + HMAC-SHA256) as `.enc` files, both on disk and in this repository — the host AV never sees plaintext signatures.
+
+- Files are decrypted **in memory only** at download time; plaintext never touches the filesystem.
+- The encryption key lives at `app/data/.secret.key` (auto-generated on first use if absent).
+- To encrypt newly added samples: `python scripts/encrypt_samples.py`.
+
+---
+
+## Remote testing scripts
 
 ```bash
 # Test IPS protections against a firewall
@@ -169,26 +171,26 @@ python tests/trigger_attacks.py \
   --target TARGET_IP \
   --file tests/protections_example.txt
 
-# Test malware download blocking
+# Test malware download blocking (streamed, never saved to disk)
 python tests/test_malware_downloads.py \
   --server http://SERVER_IP:8080 \
   --file tests/malware_files_example.txt
 ```
 
-See [tests/README.md](tests/README.md) for full documentation.
+Both routes require an authenticated session — see [tests/README.md](tests/README.md) for details.
 
 ---
 
-## Adding New Malware Samples
+## Adding new malware samples
 
 ```bash
-# Copy files into the appropriate category directory
+# Copy plaintext files into the appropriate category directory
 docker cp ./new_samples/. cp_demo_server:/usr/src/app/app/data/malware_samples/Category/
 
-# Encrypt in-place inside the container
+# Encrypt in-place inside the container (originals removed)
 docker exec cp_demo_server python scripts/encrypt_samples.py
 
-# Copy encrypted files back and commit (never commit plaintext)
+# Copy the encrypted files back and commit (never commit plaintext)
 docker cp cp_demo_server:/usr/src/app/app/data/malware_samples/. app/data/malware_samples/
 git add app/data/malware_samples/
 git commit -m "Add new encrypted samples"
@@ -196,46 +198,38 @@ git commit -m "Add new encrypted samples"
 
 ---
 
-## API Documentation
+## API documentation
 
-Swagger UI available at:
-
-```
-http://localhost:8080/apidocs/
-```
+Interactive Swagger UI is available at **`/apidocs/`** (Flasgger). Every route carries an OpenAPI docstring.
 
 ---
 
-## Optional: SSL Certificate
+## Optional: TLS certificate
+
+`run.py` runs plain HTTP by default (TLS is terminated upstream by Traefik/Dokploy). To run the Flask server directly over HTTPS, generate a cert and uncomment the `ssl_context` line in `run.py`:
 
 ```bash
 openssl req -x509 -newkey rsa:4096 -nodes \
   -out app/data/certificate/cert.pem \
   -keyout app/data/certificate/key.pem -days 365 \
   -subj "/C=CA/ST=ON/L=Ottawa/O=Demo/CN=localhost"
-
-openssl pkcs12 -export \
-  -out app/data/certificate/cp_demo_server.p12 \
-  -inkey app/data/certificate/key.pem \
-  -in app/data/certificate/cert.pem \
-  -passout pass:vpn123!
 ```
 
 ---
 
-## Optional: Run as a systemd Service
+## Optional: run as a systemd service
 
 ```bash
-sudo tee /etc/systemd/system/cp_demo_server.service > /dev/null << EOF
+sudo tee /etc/systemd/system/cp_demo_server.service > /dev/null << 'EOF'
 [Unit]
-Description=CP Demo Server
+Description=Threat Prevention Server
 After=network.target
 
 [Service]
 User=YOUR_USER
 WorkingDirectory=/path/to/cp_demo_server
 ExecStartPre=/bin/sh -c 'test -x venv/bin/python3 || (python3 -m venv venv && venv/bin/pip install -r requirements.txt)'
-ExecStart=/path/to/venv/bin/python3 run.py
+ExecStart=/path/to/cp_demo_server/venv/bin/python3 run.py
 Restart=always
 RestartSec=3
 
@@ -247,63 +241,52 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now cp_demo_server
 ```
 
-### Troubleshooting
-
-**`status=203/EXEC` — `Unable to locate executable .../venv/bin/python3`**
-
-The venv is missing or its Python symlink is broken (commonly after an OS / Python upgrade — venvs are **not portable** and hardcode paths to the system Python they were built against).
-
-Fix by rebuilding the venv in place:
-
-```bash
-cd /path/to/cp_demo_server
-sudo apt install -y python3 python3-venv python3-pip
-rm -rf venv
-python3 -m venv venv
-venv/bin/pip install --upgrade pip
-venv/bin/pip install -r requirements.txt
-ls -l venv/bin/python3   # verify it exists
-
-sudo systemctl restart cp_demo_server
-sudo systemctl status cp_demo_server
-```
-
-The `ExecStartPre` line in the unit above makes this self-healing — on next start it will recreate the venv automatically if it's missing.
-
-### Useful systemd commands
-
-```bash
-sudo systemctl status cp_demo_server          # current state
-sudo systemctl restart cp_demo_server         # restart
-sudo systemctl stop cp_demo_server            # stop
-sudo systemctl disable --now cp_demo_server   # stop + remove from boot
-journalctl -u cp_demo_server -f               # tail logs
-journalctl -u cp_demo_server -n 200 --no-pager
-systemctl cat cp_demo_server                  # show resolved unit file
-sudo systemctl edit cp_demo_server            # drop-in override
-sudo systemctl edit --full cp_demo_server     # edit full unit
-sudo systemctl daemon-reload                  # after any manual edit
-```
-
-Unit file lives at `/etc/systemd/system/cp_demo_server.service`.
+> The `ExecStartPre` line self-heals a missing/broken venv (venvs are not portable and break after an OS/Python upgrade — status `203/EXEC`). Tail logs with `journalctl -u cp_demo_server -f`.
 
 ---
 
-## Tech Stack
+## Tech stack
 
 | Layer | Technology |
 |-------|------------|
 | Web framework | Flask 3.1 |
-| Encryption | cryptography (Fernet / AES-128-CBC) |
-| UI | Bootstrap 5 + Bootstrap Icons |
+| Encryption | cryptography (Fernet — AES-128-CBC + HMAC-SHA256) |
+| UI | Bootstrap 5 + Bootstrap Icons + DataTables |
 | Database | SQLite |
 | API docs | Flasgger (Swagger) |
-| File generation | ReportLab, python-docx, Pillow, openpyxl, python-pptx |
-| Network simulation | Scapy |
-| Container | Docker (python:3.12-slim) |
+| File generation | ReportLab, python-docx, python-pptx, openpyxl/XlsxWriter, Pillow, PyRTF3, PyInstaller |
+| Network simulation | Scapy (reference only) |
+| Email | Flask-Mail |
+| Container | Docker (`python:3.12-slim`, non-root user) |
 
 ---
 
-## License
+## Project structure
 
-MIT
+```
+cp_demo_server/
+├── app/
+│   ├── data/
+│   │   ├── .secret.key              # Fernet key for malware samples
+│   │   ├── malware_samples/         # 225 samples stored as .enc files (14 categories)
+│   │   ├── generated_files/         # TE-generated downloadable files
+│   │   ├── ioc_files/               # IoC CSV/PDF/DOCX test files
+│   │   ├── certificate/             # TLS/SSL certificate + p12
+│   │   ├── email_config/            # SMTP configuration (JSON)
+│   │   └── ips_protections_demo.csv # IPS protection catalog
+│   ├── templates/                   # login, base, index, ips, av, te, https_inspection
+│   ├── static/                      # CSS, JS, favicon, logos
+│   ├── crypto_util.py               # At-rest encryption/decryption (Fernet)
+│   ├── views.py                     # All route handlers
+│   ├── file_generator.py            # TE file generation logic
+│   ├── attack_generator.py          # Scapy network attack PoC (not routed)
+│   ├── db.py                        # SQLite helpers + CSV loader
+│   └── email_service.py            # Flask-Mail wrapper
+├── scripts/
+│   └── encrypt_samples.py           # Encrypt new malware samples in-place
+├── tests/                           # Remote IPS + malware-download test scripts
+├── docker-compose.dokploy.yml       # Dokploy deployment
+├── Dockerfile
+├── requirements.txt
+└── run.py                           # Entry point (init DBs, load CSV, serve on :8080)
+```


### PR DESCRIPTION
Overhauls `README.MD` to match the Dev Hub ecosystem style guide, corrected against the actual code (`run.py`, `app/views.py`, `Dockerfile`, `docker-compose.dokploy.yml`, `crypto_util.py`, data dirs).

## What changed
- **Retitled** to the canonical display name **Threat Prevention Server**; note the repo name is `cp_demo_server`.
- Added the **Dev Hub ecosystem** line + an **Overview** section.
- Added a **Deployment** section: auto-deploys via [ubuntu-dokploy-ai](https://github.com/alshawwaf/ubuntu-dokploy-ai) at `threat.<domain>`; documents `docker-compose.dokploy.yml` and the `ADMIN_USERNAME` / `ADMIN_PASSWORD` env vars.
- Added a **Configuration** env-var table; clarified that email settings are configured in the UI and persisted to JSON (not env vars).
- **Screenshots** now embeds the real demo GIF (`app/data/readme_assets/cp_demo_server_demo.gif`) instead of a placeholder.
- Documented the previously-undocumented **HTTPS Inspection / IoC** and **email-delivery** surfaces.
- Corrected encryption wording to **Fernet (AES-128-CBC + HMAC-SHA256)** to match `crypto_util.py`.
- Aligned navbar labels (Malware Files, File Generator), trimmed the verbose SSL/systemd sections.
- **Dropped the MIT badge and License section** — there is no `LICENSE` file in the repo, so the prior claim was unsubstantiated.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)